### PR TITLE
Reuse previous signature fields when signing file.

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -6,7 +6,7 @@
 	<summary><![CDATA[eSignatures]]></summary>
 	<description><![CDATA[eSignatures]]></description>
 
-	<version>0.0.7</version>
+	<version>0.0.8</version>
 	<license>agpl</license>
 
 	<author>Joachim Bauch</author>

--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -88,6 +88,12 @@ return [
       'requirements' => $requirements,
     ],
 		[
+      'name' => 'Api#getFileMetadata',
+      'url' => '/api/{apiVersion}/metadata/{id}',
+      'verb' => 'GET',
+      'requirements' => $requirements,
+    ],
+		[
       'name' => 'Api#search',
       'url' => '/api/{apiVersion}/search',
       'verb' => 'POST',

--- a/docs/api.md
+++ b/docs/api.md
@@ -57,6 +57,22 @@ Signature fields objects must contain the keys `id` (unique id of the field),
 based on the page viewport where the top left of the page is at `0` / `0`.
 
 
+## Get metadata of file.
+
+* Method: `GET`
+* Endpoint: `/api/v1/metadata/<file_id>`
+
+* Response:
+  - Status code:
+    + `401 Unauthorized` When the user is not logged in.
+    + `403 Forbidden` When the user is not allowed to access the file.
+    + `404 Not Found` When the file was not found.
+  - Data:
+     The metadata included in the previous request to share the file. See above
+     for details. Could be an empty JSON object if no request was sent for the
+     file before.
+
+
 ## Get list of files shared by current user
 
 * Method: `GET`

--- a/lib/Metadata.php
+++ b/lib/Metadata.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCA\Esig;
+
+use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
+use OCA\Esig\Config;
+use OCA\Esig\Events\ShareEvent;
+use OCP\DB\QueryBuilder\IQueryBuilder;
+use OCP\EventDispatcher\IEventDispatcher;
+use OCP\Files\File;
+use OCP\IDBConnection;
+use OCP\ILogger;
+use OCP\IURLGenerator;
+use OCP\IUser;
+
+class Metadata {
+
+	private ILogger $logger;
+	private IDBConnection $db;
+	private IEventDispatcher $dispatcher;
+
+	public function __construct(ILogger $logger,
+								IDBConnection $db,
+								IEventDispatcher $dispatcher) {
+		$this->logger = $logger;
+		$this->db = $db;
+		$this->dispatcher = $dispatcher;
+	}
+
+  public function storeMetadata(IUser $user, File $file, ?array $metadata): void {
+		if (empty($metadata)) {
+			$this->deleteMetadata($user, $file);
+			return;
+		}
+
+		$update = $this->db->getQueryBuilder();
+		$update->update('esig_file_metadata')
+			->set('updated', $update->createFunction('now()'))
+			->set('user_id', $update->createNamedParameter($user->getUID()))
+			->set('metadata', $update->createNamedParameter(!empty($metadata) ? json_encode($metadata) : null))
+			->where($update->expr()->eq('file_id', $update->createNamedParameter($file->getId(), IQueryBuilder::PARAM_INT)));
+		if ($update->executeStatement() > 0) {
+			// Updated existing entry.
+			return;
+		}
+
+		$query = $this->db->getQueryBuilder();
+		$query->insert('esig_file_metadata')
+			->values(
+				[
+					'file_id' => $query->createNamedParameter($file->getId(), IQueryBuilder::PARAM_INT),
+					'created' => $query->createFunction('now()'),
+					'updated' => $query->createFunction('now()'),
+					'user_id' => $query->createNamedParameter($user->getUID()),
+					'metadata' => $query->createNamedParameter(!empty($metadata) ? json_encode($metadata) : null),
+				]
+			);
+
+		try {
+			$query->executeStatement();
+		} catch (UniqueConstraintViolationException $e) {
+			// Another user added the entry concurrently.
+			return;
+		}
+  }
+
+	public function getMetadata(IUser $user, File $file): ?array {
+		$query = $this->db->getQueryBuilder();
+		$query->select('*')
+			->from('esig_file_metadata')
+			->where($query->expr()->eq('file_id', $query->createNamedParameter($file->getId(), IQueryBuilder::PARAM_INT)));
+		$result = $query->executeQuery();
+		$row = $result->fetch();
+		$result->closeCursor();
+		if ($row === false) {
+			return null;
+		}
+
+		if ($row['metadata']) {
+			$row['metadata'] = json_decode($row['metadata'], true);
+		}
+		return $row['metadata'];
+	}
+
+	public function deleteMetadata(IUser $user, File $file): void {
+		$query = $this->db->getQueryBuilder();
+		$query->delete('esig_file_metadata')
+			->where($query->expr()->eq('file_id', $query->createNamedParameter($file->getId(), IQueryBuilder::PARAM_INT)));
+		$query->executeStatement();
+	}
+
+}

--- a/lib/Migration/Version1000Date20221117161043.php
+++ b/lib/Migration/Version1000Date20221117161043.php
@@ -1,0 +1,50 @@
+<?php
+namespace OCA\Esig\Migration;
+
+use Doctrine\DBAL\Types\Type;
+use Doctrine\DBAL\Types\Types;
+use OCP\DB\ISchemaWrapper;
+use OCP\Migration\SimpleMigrationStep;
+use OCP\Migration\IOutput;
+
+class Version1000Date20221117161043 extends SimpleMigrationStep {
+
+	/**
+	 * @param IOutput $output
+	 * @param \Closure $schemaClosure The `\Closure` returns a `ISchemaWrapper`
+	 * @param array $options
+	 * @return null|ISchemaWrapper
+	 */
+	public function changeSchema(IOutput $output, \Closure $schemaClosure, array $options) {
+		$schema = $schemaClosure();
+
+		if (!$schema->hasTable('esig_file_metadata')) {
+			$table = $schema->createTable('esig_file_metadata');
+			$table->addColumn('id', Types::BIGINT, [
+				'autoincrement' => true,
+				'notnull' => true,
+			]);
+			$table->addColumn('file_id', Types::BIGINT, [
+				'notnull' => true,
+				'length' => 64,
+			]);
+			$table->addColumn('created', Types::DATETIMETZ_MUTABLE, [
+				'notnull' => true,
+			]);
+			$table->addColumn('updated', Types::DATETIMETZ_MUTABLE, [
+				'notnull' => true,
+			]);
+			$table->addColumn('user_id', Types::STRING, [
+				'notnull' => true,
+				'length' => 255,
+			]);
+			$table->addColumn('metadata', Types::TEXT, [
+				'notnull' => true,
+			]);
+			$table->setPrimaryKey(['id']);
+			$table->addUniqueIndex(['file_id'], 'efm_file_id');
+		}
+		return $schema;
+	}
+
+}

--- a/src/views/ShareDialogView.vue
+++ b/src/views/ShareDialogView.vue
@@ -142,7 +142,7 @@ import { loadState } from '@nextcloud/initial-state'
 import { showSuccess, showError } from '@nextcloud/dialogs'
 import { generateRemoteUrl } from '@nextcloud/router'
 
-import { shareFile, search } from '../services/apiservice.js'
+import { shareFile, search, getMetadata } from '../services/apiservice.js'
 import SelectorDialogModal from '../components/SelectorDialogModal.vue'
 import SearchResults from '../components/SearchResults.vue'
 
@@ -179,6 +179,7 @@ export default {
 			signaturePositions: [],
 			settings: {},
 			signed_save_mode: null,
+			prevMetadata: {},
 		}
 	},
 
@@ -218,7 +219,7 @@ export default {
 	},
 
 	created() {
-		this.$root.$watch('fileModel', (newValue) => {
+		this.$root.$watch('fileModel', async (newValue) => {
 			this.fileModel = newValue
 			this.signed_save_mode = this.settings.signed_save_mode
 			this.recipient_type = 'user'
@@ -232,6 +233,12 @@ export default {
 			this.emailResults = {}
 			this.shareLoading = false
 			this.signaturePositions = []
+			if (newValue) {
+				const metadata = await getMetadata(newValue.id)
+				if (metadata && metadata.signature_fields) {
+					this.signaturePositions = metadata.signature_fields
+				}
+			}
 		})
 	},
 


### PR DESCRIPTION
- When a request is sent successfully, the signature fields are stored on the server.
- When a signature is requested for the same file, the previous signature fields are reused (and can be modified).