### PR TITLE
Encode action into tokens to prevent invalid usage.

### DIFF
--- a/lib/Client.php
+++ b/lib/Client.php
@@ -24,7 +24,7 @@ class Client {
 	}
 
 	public function shareFile(File $file, array $recipients, ?array $metadata, array $account, string $server): array {
-		$token = $this->tokens->getToken($account, $file->getName());
+		$token = $this->tokens->getToken($account, $file->getName(), 'upload');
 
 		$client = $this->clientService->newClient();
 		$headers = [
@@ -70,7 +70,7 @@ class Client {
 	}
 
 	public function signFile(string $id, array $multipart, array $account, string $server): array {
-		$token = $this->tokens->getToken($account, $id);
+		$token = $this->tokens->getToken($account, $id, 'sign');
 
 		$client = $this->clientService->newClient();
 		$headers = [
@@ -90,7 +90,7 @@ class Client {
 	}
 
 	public function deleteFile(string $id, array $account, string $server): array {
-		$token = $this->tokens->getToken($account, $id);
+		$token = $this->tokens->getToken($account, $id, 'delete');
 
 		$client = $this->clientService->newClient();
 		$headers = [
@@ -110,21 +110,21 @@ class Client {
 
 	public function getOriginalUrl(string $id, array $account, string $server): string {
 		$url = $server . 'api/v1/files/' . rawurlencode($account['id']) . '/' . rawurlencode($id);
-		$token = $this->tokens->getToken($account, $id);
+		$token = $this->tokens->getToken($account, $id, 'download-original');
 		$url .= '?token=' . urlencode($token);
 		return $url;
 	}
 
 	public function getSourceUrl(string $id, array $account, string $server): string {
 		$url = $server . 'api/v1/files/' . rawurlencode($account['id']) . '/source/' . rawurlencode($id);
-		$token = $this->tokens->getToken($account, $id);
+		$token = $this->tokens->getToken($account, $id, 'download-source');
 		$url .= '?token=' . urlencode($token);
 		return $url;
 	}
 
 	public function getSignedUrl(string $id, array $account, string $server): string {
 		$url = $server . 'api/v1/files/' . rawurlencode($account['id']) . '/sign/' . rawurlencode($id);
-		$token = $this->tokens->getToken($account, $id);
+		$token = $this->tokens->getToken($account, $id, 'download-signed');
 		$url .= '?token=' . urlencode($token);
 		return $url;
 	}

--- a/lib/Tokens.php
+++ b/lib/Tokens.php
@@ -23,13 +23,14 @@ class Tokens {
 		$this->config = $config;
 	}
 
-	public function getToken(array $account, string $subject): string {
+	public function getToken(array $account, string $subject, string $action): string {
 		$now = $this->timeFactory->getTime();
 		$claims = [
 			'iss' => $this->urlGenerator->getAbsoluteURL(''),
 			'sub' => $subject,
 			'iat' => $now,
 			'exp' => $now + (5 * 60),
+			'act' => $action,
 		];
 		$jwt = JWT::encode($claims, $account['secret'], 'EdDSA');
 		return $jwt;


### PR DESCRIPTION
Previously it was possible to use a token for a file download to delete the file.