### PR TITLE
Delete recipients entries when a request is deleted.

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -6,7 +6,7 @@
 	<summary><![CDATA[eSignatures]]></summary>
 	<description><![CDATA[eSignatures]]></description>
 
-	<version>0.0.13</version>
+	<version>0.0.14</version>
 	<license>agpl</license>
 
 	<author>Joachim Bauch</author>

--- a/lib/Migration/Version1000Date20230213115732.php
+++ b/lib/Migration/Version1000Date20230213115732.php
@@ -1,0 +1,46 @@
+<?php
+namespace OCA\Esig\Migration;
+
+use Doctrine\DBAL\Types\Type;
+use Doctrine\DBAL\Types\Types;
+use OCP\DB\ISchemaWrapper;
+use OCP\DB\QueryBuilder\IQueryBuilder;
+use OCP\IDBConnection;
+use OCP\Migration\SimpleMigrationStep;
+use OCP\Migration\IOutput;
+use Throwable;
+
+class Version1000Date20230213115732 extends SimpleMigrationStep {
+
+	protected IDBConnection $db;
+
+	public function __construct(IDBConnection $db) {
+		$this->db = $db;
+	}
+
+	public function postSchemaChange(IOutput $output, \Closure $schemaClosure, array $options): void {
+		// Delete recipients entries for no-longer existing requests.
+		$this->db->beginTransaction();
+		try {
+			$query = $this->db->getQueryBuilder();
+			$query->select('id')
+				->from('esig_requests');
+			$result = $query->executeQuery();
+			$ids = [];
+			while ($row = $result->fetch()) {
+				$ids[] = $row['id'];
+			}
+			$result->closeCursor();
+
+			$query = $this->db->getQueryBuilder();
+			$query->delete('esig_recipients')
+				->where($query->expr()->notIn('request_id', $query->createNamedParameter($ids, IQueryBuilder::PARAM_STR_ARRAY)));
+			$query->executeStatement();
+			$this->db->commit();
+		} catch (Throwable $e) {
+			$this->db->rollBack();
+			throw $e;
+		}
+	}
+
+}

--- a/lib/Requests.php
+++ b/lib/Requests.php
@@ -388,6 +388,14 @@ class Requests {
 		$query = $this->db->getQueryBuilder();
 		$query->delete('esig_requests')
 			->where($query->expr()->eq('id', $query->createNamedParameter($id)));
+		if (!$query->executeStatement()) {
+			return;
+		}
+
+		// Explicitly delete recipients for databases without foreign keys.
+		$query = $this->db->getQueryBuilder();
+		$query->delete('esig_recipients')
+			->where($query->expr()->eq('request_id', $query->createNamedParameter($id)));
 		$query->executeStatement();
 	}
 


### PR DESCRIPTION
This helps cleaning up the database if foreign keys are not supported (i.e. with sqlite during development).

Closes #53 