### PR TITLE
Add capability "has-account".

### DIFF
--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -3,6 +3,7 @@ title: Capabilities
 ---
 
 ## 1.0
+* `has-account` - An account has been setup and the app can be used.
 * `features => multiple-recipients` - Requesting signatures from multiple recipients is supported.
 * `features => sign-anonymous` - Requesting signatures from anonymous users (i.e. emails) is supported.
 * `features => verify-signatures` - Verifying signatures of documents is supported.

--- a/lib/Capabilities.php
+++ b/lib/Capabilities.php
@@ -24,6 +24,7 @@ declare(strict_types=1);
  */
 namespace OCA\Esig;
 
+use OCA\Esig\AppInfo\Application;
 use OCP\App\IAppManager;
 use OCP\Capabilities\IPublicCapability;
 use OCP\IUserSession;
@@ -44,6 +45,7 @@ class Capabilities implements IPublicCapability {
 	public function getCapabilities(): array {
 		$user = $this->userSession->getUser();
 
+		$account = $this->config->getAccount();
 		$capabilities = [
 			'features' => [
 				'multiple-recipients',
@@ -56,7 +58,8 @@ class Capabilities implements IPublicCapability {
 				],
 				'user' => [],
 			],
-			'version' => $this->appManager->getAppVersion('esig'),
+			'version' => $this->appManager->getAppVersion(Application::APP_ID),
+			'has-account' => !empty($account['id']) && !empty($account['secret']),
 		];
 
 		if ($user) {


### PR DESCRIPTION
This is somethins you should check in the iOS app. If the `has-account` capability is false, the app has not been setup yet in Nextcloud and requesting signatures will not be possible.