### PR TITLE
Allow signing a document yourself directly

### DIFF
--- a/lib/FilesLoader.php
+++ b/lib/FilesLoader.php
@@ -32,6 +32,7 @@ use OCP\Collaboration\Resources\LoadAdditionalScriptsEvent;
 use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\EventDispatcher\IEventListener;
+use OCP\IUserSession;
 use OCP\Util;
 
 /**
@@ -41,13 +42,16 @@ class FilesLoader implements IEventListener {
 	protected IInitialState $initialState;
 	protected IAppManager $appManager;
 	protected Config $config;
+	protected IUserSession $userSession;
 
 	public function __construct(IInitialState $initialState,
 		IAppManager $appManager,
-		Config $config) {
+		Config $config,
+		IUserSession $userSession) {
 		$this->initialState = $initialState;
 		$this->appManager = $appManager;
 		$this->config = $config;
+		$this->userSession = $userSession;
 	}
 
 	public static function register(IEventDispatcher $dispatcher): void {
@@ -79,6 +83,16 @@ class FilesLoader implements IEventListener {
 			[
 				'signed_save_mode' => $this->config->getSignedSaveMode(),
 			]
+		);
+
+		$userSettings = [];
+		$user = $this->userSession->getUser();
+		if ($user && $this->config->getSignatureImage($user)) {
+			$userSettings['has-signature-image'] = true;
+		}
+		$this->initialState->provideInitialState(
+			'user-settings',
+			$userSettings
 		);
 	}
 

--- a/src/services/apiservice.js
+++ b/src/services/apiservice.js
@@ -33,18 +33,18 @@ const isEmpty = (obj) => {
 }
 
 const shareFile = async (file_id, recipients, options, metadata) => {
-	return axios.post(generateOcsUrl('apps/certificate24/api/v1/share'), {
+	const response = await axios.post(generateOcsUrl('apps/certificate24/api/v1/share'), {
 		file_id,
 		recipients,
 		options: !isEmpty(options) ? options : null,
 		metadata: !isEmpty(metadata) ? metadata : null,
-	}).then(() => {
-		if (isEmpty(metadata)) {
-			delete metadataCache[file_id]
-		} else {
-			metadataCache[file_id] = metadata
-		}
 	})
+	if (isEmpty(metadata)) {
+		delete metadataCache[file_id]
+	} else {
+		metadataCache[file_id] = metadata
+	}
+	return response
 }
 
 const getRequests = async (include_signed) => {

--- a/src/views/ShareDialogView.vue
+++ b/src/views/ShareDialogView.vue
@@ -151,6 +151,16 @@
 						</template>
 						{{ t('certificate24', 'Select signature position') }}
 					</NcButton>
+					<NcButton type="secondary"
+						:disabled="selfSignLoading || !signaturePositions.length"
+						:title="t('certificate24', 'Sign yourself')"
+						@click="signYourself">
+						<template #icon>
+							<NcLoadingIcon v-show="selfSignLoading" :size="24" />
+							<Draw v-show="!selfSignLoading" />
+						</template>
+						{{ t('certificate24', 'Sign yourself') }}
+					</NcButton>
 					<NcButton type="primary"
 						:disabled="shareLoading || !recipients.length"
 						:title="t('certificate24', 'Request signature')"
@@ -168,12 +178,16 @@
 				:signature-positions="signaturePositions"
 				:recipients="recipients"
 				@close="closeSelectModal" />
+			<SignDialogModal v-if="selfSignRequest"
+				:request="selfSignRequest"
+				@close="onSelfSigned" />
 		</NcModal>
 	</div>
 </template>
 
 <script>
 import Delete from 'vue-material-design-icons/Delete.vue'
+import Draw from 'vue-material-design-icons/Draw.vue'
 import FileSign from 'vue-material-design-icons/FileSign.vue'
 import Magnify from 'vue-material-design-icons/Magnify.vue'
 import NcActions from '@nextcloud/vue/components/NcActions'
@@ -185,6 +199,7 @@ import NcTextField from '@nextcloud/vue/components/NcTextField'
 import NcListItemIcon from '@nextcloud/vue/components/NcListItemIcon'
 import NcLoadingIcon from '@nextcloud/vue/components/NcLoadingIcon'
 import debounce from 'debounce'
+import { getCurrentUser } from '@nextcloud/auth'
 import { loadState } from '@nextcloud/initial-state'
 import { showSuccess, showError } from '@nextcloud/dialogs'
 import { t, n } from '@nextcloud/l10n'
@@ -193,6 +208,7 @@ import { ShareType } from '@nextcloud/sharing'
 import { shareFile, search, getMetadata } from '../services/apiservice.js'
 import getVinegarApi from '../services/vinegarapi.js'
 import SelectorDialogModal from '../components/SelectorDialogModal.vue'
+import SignDialogModal from '../components/SignDialogModal.vue'
 import SearchResults from '../components/SearchResults.vue'
 
 export default {
@@ -200,6 +216,7 @@ export default {
 
 	components: {
 		Delete,
+		Draw,
 		FileSign,
 		Magnify,
 		NcActions,
@@ -211,6 +228,7 @@ export default {
 		NcListItemIcon,
 		NcLoadingIcon,
 		SelectorDialogModal,
+		SignDialogModal,
 		SearchResults,
 	},
 
@@ -235,6 +253,8 @@ export default {
 			settings: {},
 			signed_save_mode: null,
 			prevMetadata: {},
+			selfSignLoading: false,
+			selfSignRequest: null,
 		}
 	},
 
@@ -292,6 +312,8 @@ export default {
 			this.shareLoading = false
 			this.signaturePositions = []
 			this.recipients = []
+			this.selfSignLoading = false
+			this.selfSignRequest = null
 			this.clearError()
 			if (newValue) {
 				const metadata = await getMetadata(this.fileid)
@@ -612,40 +634,127 @@ export default {
 				this.closeModal()
 				showSuccess(t('certificate24', 'Requested signature.'))
 			} catch (error) {
-				this.shareLoading = false
 				console.error('Could not request signature', this.fileModel, error)
-				const response = error.response
-				const data = response.data.ocs?.data || {}
-				let errorMessage = ''
-				switch (data.error) {
-				case 'unknown_user':
-					errorMessage = t('certificate24', 'Unknown user.')
-					break
-				case 'invalid_email':
-					errorMessage = t('certificate24', 'Invalid email address.')
-					break
-				case 'error_connecting':
-					errorMessage = t('certificate24', 'Error connecting to Certificate24 service.')
-					break
-				case 'error_encrypted_file':
-					errorMessage = t('certificate24', 'The file is encrypted and can not be signed.')
-					break
-				case 'error_signed_file':
-					errorMessage = t('certificate24', 'The file is already signed and can not be signed again.')
-					break
-				default:
-					if (data.error) {
-						errorMessage = t('certificate24', 'Error while requesting signature ({error}).', {
-							error: data.error,
-						})
-					} else {
-						errorMessage = t('certificate24', 'Error while requesting signature.')
-					}
-				}
-				this.renderError(errorMessage)
+				this.renderShareError(error)
 			} finally {
 				this.shareLoading = false
 			}
+		},
+
+		renderShareError(error) {
+			const data = error.response?.data?.ocs?.data || {}
+			let errorMessage = ''
+			switch (data.error) {
+			case 'unknown_user':
+				errorMessage = t('certificate24', 'Unknown user.')
+				break
+			case 'invalid_email':
+				errorMessage = t('certificate24', 'Invalid email address.')
+				break
+			case 'error_connecting':
+				errorMessage = t('certificate24', 'Error connecting to Certificate24 service.')
+				break
+			case 'error_encrypted_file':
+				errorMessage = t('certificate24', 'The file is encrypted and can not be signed.')
+				break
+			case 'error_signed_file':
+				errorMessage = t('certificate24', 'The file is already signed and can not be signed again.')
+				break
+			default:
+				if (data.error) {
+					errorMessage = t('certificate24', 'Error while requesting signature ({error}).', {
+						error: data.error,
+					})
+				} else {
+					errorMessage = t('certificate24', 'Error while requesting signature.')
+				}
+			}
+			this.renderError(errorMessage)
+		},
+
+		async signYourself() {
+			if (!this.fileModel) {
+				showError(t('certificate24', 'No file selected.'))
+				return
+			}
+
+			const user = getCurrentUser()
+			if (!user) {
+				this.renderError(t('certificate24', 'Could not determine the current user.'))
+				return
+			}
+
+			let signaturePositions = this.signaturePositions
+			if (!signaturePositions || !signaturePositions.length) {
+				this.renderError(t('certificate24', 'Please create signature fields first.'))
+				return
+			}
+
+			let missingSignatures = true
+			signaturePositions = signaturePositions.map((e) => {
+				if (this.isSignatureField(e)) {
+					missingSignatures = false
+				}
+				if (!e.type) {
+					delete e.type
+				}
+				delete e.recipient_idx
+				return e
+			})
+			if (missingSignatures) {
+				this.renderError(t('certificate24', 'Please create signature fields first.'))
+				return
+			}
+
+			this.clearError()
+			this.selfSignLoading = true
+			try {
+				// Ensure the serverside API is available before creating the request.
+				await getVinegarApi()
+
+				const metadata = {
+					version: '1.0',
+					signature_fields: signaturePositions,
+				}
+				const options = {
+					signed_save_mode: this.signed_save_mode,
+				}
+				const recipients = [{
+					type: 'user',
+					value: user.uid,
+				}]
+				const response = await shareFile(this.fileid, recipients, options, metadata)
+				const requestId = response?.data?.ocs?.data?.request_id
+				if (!requestId) {
+					throw new Error('missing_request_id')
+				}
+
+				this.selfSignRequest = {
+					request_id: requestId,
+					filename: this.fileModel.basename || this.fileModel.name,
+					metadata,
+				}
+			} catch (error) {
+				console.error('Could not sign document', this.fileModel, error)
+				const msg = error.message || error
+				switch (msg) {
+				case 'client_unsupported':
+					showError(t('certificate24', 'The server requires a newer version of the app. Please contact your administrator.'))
+					break
+				case 'server_unsupported':
+					showError(t('certificate24', 'This app requires a newer version of the server. Please contact your administrator.'))
+					break
+				default:
+					this.renderShareError(error)
+				}
+			} finally {
+				this.selfSignLoading = false
+			}
+		},
+
+		onSelfSigned() {
+			this.selfSignRequest = null
+			this.closeModal()
 		},
 
 		openSelectModal() {


### PR DESCRIPTION
Adds a "Sign yourself" button to the request-signature dialog. After positioning a signature field, it creates a request with the current user as the only recipient and opens the existing sign dialog, so the document can be signed right away using the saved signature image.

The files integration now also provides the `user-settings` initial state so the "embed personal signature" option works in that context.